### PR TITLE
Formik datepicker fix

### DIFF
--- a/src/FormikDatepicker.tsx
+++ b/src/FormikDatepicker.tsx
@@ -5,6 +5,8 @@ import { KeyboardDatePickerProps } from "@material-ui/pickers/DatePicker/DatePic
 import { FormHelperTextProps } from "@material-ui/core/FormHelperText";
 import { FormikField } from "./FormikField";
 import { hasError, getHelperText } from "./utils";
+import makeStyles from "@material-ui/core/styles/makeStyles";
+
 
 interface IBaseProps {
   name: string;
@@ -17,6 +19,7 @@ interface IBaseProps {
   formHelperTextProps?: FormHelperTextProps;
   fieldProps?: {};
   validate?: any;
+  removeButton?: true;
 }
 
 export type FormikDatepickerProps = IBaseProps &
@@ -36,6 +39,17 @@ const utils = {
   dateFns: "DateFnsUtils",
 };
 
+const useStyles = makeStyles({
+  datePickerStyles: (props:IBaseProps) => ({
+      "& p": {
+        color: "red" // it was grey when not empty so had to override for consistency
+      },
+      "& button": {
+        display: props.removeButton ? "none" : undefined
+      }
+    }),
+})
+
 export function FormikDatepicker(props: FormikDatepickerProps) {
   const {
     name,
@@ -47,6 +61,8 @@ export function FormikDatepicker(props: FormikDatepickerProps) {
     validate,
     ...others
   } = props;
+
+  const classes = useStyles(props);
 
   // Check context for moment/datefns because formats are different
   const context = React.useContext(MuiPickersContext) || {};
@@ -72,6 +88,7 @@ export function FormikDatepicker(props: FormikDatepickerProps) {
           <KeyboardDatePicker
             {...defaultProps}
             {...field}
+            className={classes.datePickerStyles}
             value={field.value || null}
             onChange={(date) => {
               form.setFieldValue(

--- a/src/FormikDatepicker.tsx
+++ b/src/FormikDatepicker.tsx
@@ -76,7 +76,7 @@ export function FormikDatepicker(props: FormikDatepickerProps) {
             onChange={(date) => {
               form.setFieldValue(
                 name,
-                date != null ? date.toISOString() : date
+                date
               );
             }}
             error={hasError(name, form, error)}

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -58,5 +58,5 @@ export function getHelperText(
   const errorString = getErrors(form.errors, name);
   const touched = getErrors(form.touched, name);
 
-  return (form.errors && touched === true && errorString) || helperText;
+  return (form.errors && touched && errorString) || helperText;
 }


### PR DESCRIPTION
Fixed error not showing when input field has a value. This was caused by the `touched === true` comparison.

Removed `date.toISOString()` from `KeyboardDatepicker`'s `onChange` property because it overrides standard behavior and introduces bugs (see the same bugfix on Thomas' PR [here](https://github.com/DCCS-IT-Business-Solutions/react-formik-mui/pull/24/commits/6fa6cf62b9ef579dbb012f0347ad3c5c594938bd)).

Added styling to component because the error message was red when the input was empty, and grey when it wasn't. I forced it to be red always for consistency.
Also added possibility of removing the datepicker button through a prop.